### PR TITLE
Even dash pattern for closed shapes inside DashedVMObject

### DIFF
--- a/manim/mobject/types/vectorized_mobject.py
+++ b/manim/mobject/types/vectorized_mobject.py
@@ -1499,10 +1499,17 @@ class DashedVMobject(VMobject):
             # This determines the length of each "dash"
             full_d_alpha = 1.0 / num_dashes
             partial_d_alpha = full_d_alpha * ps_ratio
+            
+            # Shifts the alphas and removes the last dash
+            # to give closed shapes even spacing
+            if vmobject.is_closed():
+                alphas += (partial_d_alpha / 2)
+                np.delete(alphas, -1)
 
             # Rescale so that the last point of vmobject will
             # be the end of the last dash
-            alphas /= 1 - full_d_alpha + partial_d_alpha
+            if not vmobject.is_closed():
+                alphas /= 1 - full_d_alpha + partial_d_alpha
 
             self.add(
                 *[


### PR DESCRIPTION
<!--
Thank you for contributing to manim!

Please ensure that your pull request works with the latest
version of manim from this repository.
-->

## Motivation
<!-- Outline your motivation: In what way do your changes improve the library? -->
A closed shape inside a `DashedVMObject` results in an ugly double length dash between the start and end points, resulting in an uneven dash pattern.

## Overview / Explanation for Changes
<!-- Give an overview of your changes and explain how they
resolve the situation described in the previous section.

For PRs introducing new features, please provide code snippets
using the newly introduced functionality and ideally even the
expected rendered output. -->
This fix detects if a shape is a closed shape (such as `Circle`) and shifts the dash pattern to have a half gap at each end, resulting in a much prettier result.

## Oneline Summary of Changes
<!-- Please update the lines below with a oneline summary
for your changes. It will be included in the list of upcoming changes at
https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release -->
```
- Added detection for closed shapes in DashedVMObject to ensure even dash patterns.
```

## Testing Status
<!-- Optional (but recommended): your computer specs and
what tests you ran with their results, if any. This section
is also intended for other testing-related comments. -->
Before and after pictures:

![old](https://user-images.githubusercontent.com/25301457/103291029-d03c9580-49e2-11eb-9fff-5c3c4656cf13.png)
![new](https://user-images.githubusercontent.com/25301457/103291041-d6327680-49e2-11eb-90fe-3a99356d4a8a.png)


## Acknowledgements
- [x] I have read the [Contributing Guidelines](https://docs.manim.community/en/latest/contributing.html)

<!-- Once again, thanks for helping out by contributing to manim! -->


<!-- Do not modify the lines below. -->
## Reviewer Checklist
- [ ] Newly added functions/classes are either private or have a docstring
- [ ] Newly added functions/classes have [tests](https://github.com/ManimCommunity/manim/wiki/Testing) added and (optional) examples in the docs
- [ ] Newly added documentation builds, looks correctly formatted, and adds no additional build warnings
- [ ] The oneline summary has been included [in the wiki](https://github.com/ManimCommunity/manim/wiki/Changelog-for-next-release)
